### PR TITLE
Fix convertToG on 32-bit platforms

### DIFF
--- a/AccelerometerMMA8451/AccelerometerMMA8451.cpp
+++ b/AccelerometerMMA8451/AccelerometerMMA8451.cpp
@@ -26,7 +26,7 @@ void AccelerometerMMA8451::deviceActivation(DeviceActivation activation) {
 
 bool AccelerometerMMA8451::isDataReady() {
     STATUSbits status = { 0 };
-    int v = readRegister(STATUS);
+    signed short v = readRegister(STATUS);
     if (v < 0) {
         lastError = (CommunicationError) -(v);
         return false;
@@ -241,7 +241,7 @@ float AccelerometerMMA8451::convertToG(unsigned char* buf, bool fastRead) {
         g = ((char) buf[0]) / counts[xyzDataCfg.FS];
     } else {
         float counts[] = { 16384.0, 8192.0, 4096.0 };
-        int aux = (buf[0] << 8) | buf[1];
+        signed short aux = (buf[0] << 8) | buf[1];
         g = aux / counts[xyzDataCfg.FS];
     }
     return g;

--- a/AccelerometerMMA8451/AccelerometerMMA8451.cpp
+++ b/AccelerometerMMA8451/AccelerometerMMA8451.cpp
@@ -1,10 +1,10 @@
 /**
  * Arduino - Accelerometer driver
- * 
+ *
  * AccelerometerMMA8451.cpp
- * 
+ *
  * The implementation of the MMA8451 accelerometer.
- * 
+ *
  * @author Dalmir da Silva <dalmirdasilva@gmail.com>
  */
 
@@ -26,7 +26,7 @@ void AccelerometerMMA8451::deviceActivation(DeviceActivation activation) {
 
 bool AccelerometerMMA8451::isDataReady() {
     STATUSbits status = { 0 };
-    signed short v = readRegister(STATUS);
+    short v = readRegister(STATUS);
     if (v < 0) {
         lastError = (CommunicationError) -(v);
         return false;
@@ -241,7 +241,7 @@ float AccelerometerMMA8451::convertToG(unsigned char* buf, bool fastRead) {
         g = ((char) buf[0]) / counts[xyzDataCfg.FS];
     } else {
         float counts[] = { 16384.0, 8192.0, 4096.0 };
-        signed short aux = (buf[0] << 8) | buf[1];
+        short aux = (buf[0] << 8) | buf[1];
         g = aux / counts[xyzDataCfg.FS];
     }
     return g;


### PR DESCRIPTION
The library compiles just fine for ESP8266, but the G calculation is wrong, as `int` seems to be of different size on Arduino and ESP8266. Using `signed short` solves the issue.